### PR TITLE
add `ext_ncd_get_var_ti_real` stub so UPP can compile without wrf-io library

### DIFF
--- a/sorc/ncep_post.fd/io_int_stubs.f
+++ b/sorc/ncep_post.fd/io_int_stubs.f
@@ -134,6 +134,9 @@ subroutine int_gen_ti_header_c ( hdrbuf, hdrbufsize, itypesize, typesize, &
 END SUBROUTINE int_gen_ti_header_c
 
 
+subroutine ext_ncd_get_var_ti_real(DataHandle,Element,Var,Data,Count,OutCount,Status)
+  return
+end subroutine ext_ncd_get_var_ti_real
 
 
 


### PR DESCRIPTION
The io_int_stubs.f is used in place of the wrf-io library when the UPP compiles without that library. Any ext_ncd subroutine called by the UPP must also exist in io_int_stubs.f.

This PR adds the ext_ncd_get_var_ti_real stub.